### PR TITLE
Add description to roadmap items

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Create an issue and put somewhere on the description the following tracker strin
 
 Replace the values accordingly. Make sure the organization and roadmap name exist and they're typed correctly.
 
+We encourage you to put an issue template with the according organization and roadmap names so it's easily to start tracking your issues :)
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/http/helpers.rb
+++ b/http/helpers.rb
@@ -24,7 +24,11 @@ module Http
       organization = Roadmapster::Wizeline::Organization.new(token: api_token).by_name(tracker_data[:organization_name])
       roadmap = Roadmapster::Wizeline::Roadmap.new(token: api_token, organization: organization)
       roadmap_id = roadmap.by_name(tracker_data[:roadmap_name])[:id]
-      roadmap.create_unit(roadmap_id: roadmap_id, name: "Github ##{issue.number}:  #{issue.title}")
+      roadmap.create_unit(
+        roadmap_id: roadmap_id,
+        name: "Github ##{issue.number}:  #{issue.title}",
+        description: issue.description
+      )
     end
   end
 end

--- a/lib/roadmapster/webhooks/github_issue.rb
+++ b/lib/roadmapster/webhooks/github_issue.rb
@@ -21,7 +21,7 @@ module Roadmapster
       end
 
       def contains_tracker?
-        @tracker ||= HINT_REGEX.match(description)[0]
+        @tracker ||= HINT_REGEX.match(issue_body)[0]
         !@tracker.nil?
       end
 
@@ -41,8 +41,12 @@ module Roadmapster
         @payload[:issue][:number]
       end
 
-      def description
+      def issue_body
         @payload[:issue][:body]
+      end
+
+      def description
+        @payload[:issue][:body].sub HINT_REGEX, ''
       end
     end
   end

--- a/lib/roadmapster/wizeline/roadmap.rb
+++ b/lib/roadmapster/wizeline/roadmap.rb
@@ -7,7 +7,7 @@ module Roadmapster
     class Roadmap
       include Roadmapster::Wizeline::BaseApi
 
-      DEFAULT_TYPE_ID = '_0668tj9T5q5MTuqLxlsAA'
+      DEFAULT_TYPE_ID = 'bwhWdvctSnerDNEAnrRQMA'
 
       def initialize(token:, organization:)
         @api_token = token
@@ -27,12 +27,12 @@ module Roadmapster
         all[:data].select { |r| r[:name] == name }.first
       end
 
-      def create_unit(roadmap_id:, name:, **options)
+      def create_unit(roadmap_id:, name:, description:, **options)
         item_payload = {
           id: '-:PENDING:-',
           parent_id: options[:parent_id],
           position: options[:position] || 1,
-          unit: unit_options(name, options)
+          unit: unit_options(name, description, options)
         }
 
         post("roadmaps/#{roadmap_id}/items", item_payload, organization_domain: @organization_domain)
@@ -40,10 +40,10 @@ module Roadmapster
 
       private
 
-      def unit_options(name, options)
+      def unit_options(name, description, options)
         default_unit_options.merge({
           name: name,
-          description: options[:description],
+          description: description,
           start_date: options[:start_date],
           end_date: options[:end_date],
           owner_id: options[:owner_id],

--- a/spec/wizeline_api/roadmap_spec.rb
+++ b/spec/wizeline_api/roadmap_spec.rb
@@ -26,8 +26,13 @@ RSpec.describe Roadmapster::Wizeline::Roadmap do
 
   vcr_options = { cassette_name: 'wizeline/create_roadmap_units' }
   it 'creates a roadmap unit with default values', vcr: vcr_options do
-    new_roadmap_unit = @roadmaps.create_unit(roadmap_id: 'QfU11YeHQ3uhpdwzypMmRw', name: 'TEST_UNIT_123')
+    new_roadmap_unit = @roadmaps.create_unit(
+      roadmap_id: 'QfU11YeHQ3uhpdwzypMmRw',
+      name: 'TEST_UNIT_123',
+      description: 'A very reasonable description'
+    )
     expect(new_roadmap_unit).to be_a(Hash)
+    expect(new_roadmap_unit[:id]).to eq('Ei_aUbZLTVaP0B1eFZacgA')
   end
 
   vcr_options = { cassette_name: 'wizeline/get_roadmaps' }


### PR DESCRIPTION
## Things done in this PR

1. Made a small refactor in the `Github Issue` entity to differentiate between the description and the issue body since the organization name and roadmap name was pulled from the `description` field from the `Github Issue` entity, but it was not aligned with the real description is, so made a rename in there. Let me know what you think.

## Important stuff with type ids

Seems like each roadmap has a different `Type ID` for the items, so I believe we should make it configurable via an Env variable (?) 

I left the type id of my roadmap in the diff so you can see it, but will remove.