### PR TITLE
RuboCop StringReplacement: Use delete instead of gsub

### DIFF
--- a/http/helpers.rb
+++ b/http/helpers.rb
@@ -14,7 +14,7 @@ module Http
     end
 
     def tracker_parser(tracker)
-      tokens = tracker.gsub!('[', '').gsub!(']', '').split('/')
+      tokens = tracker.delete!('[]').split('/')
       { organization_name: tokens[1], roadmap_name: tokens[2] }
     end
 


### PR DESCRIPTION
Fixes: https://github.com/iaserrat/roadmapster/issues/16

RuboCop recommends using `delete!` instead of `gsub!` for performance.

See: http://rubocop.readthedocs.io/en/latest/cops_performance/#performancestringreplacement

This pull request removes our only improper use of `.gsub`.