### PR TITLE
Run RuboCop --auto-correct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
@@ -7,10 +9,10 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 group :test, :development do
-  gem 'vcr'
-  gem 'webmock'
-  gem 'pry'
   gem 'foreman'
+  gem 'pry'
   gem 'rerun'
   gem 'terminal-notifier'
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -8,4 +10,4 @@ task :serve do
   sh 'rerun foreman start'
 end
 
-task :default => :serve
+task default: :serve

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "roadmapster"
+require 'bundler/setup'
+require 'roadmapster'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "roadmapster"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.join(File.dirname(__FILE__), 'http/github_routes.rb')
 
 $stdout.sync = true

--- a/http/github_routes.rb
+++ b/http/github_routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 require 'sinatra/json'
 require_relative 'helpers'
@@ -24,9 +26,7 @@ module Http
     post '/webhooks/issues' do
       payload = JSON.parse(request.body.read, symbolize_names: true)
       issue = issue_from_payload(payload)
-      if issue.should_track?
-        create_wizeline_issue(issue)
-      end
+      create_wizeline_issue(issue) if issue.should_track?
       json :ok
     end
   end

--- a/http/helpers.rb
+++ b/http/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'roadmapster'
 
 module Http

--- a/lib/roadmapster.rb
+++ b/lib/roadmapster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'roadmapster/version'
 require 'roadmapster/wizeline/base_api'
 require 'roadmapster/wizeline/organization'

--- a/lib/roadmapster/version.rb
+++ b/lib/roadmapster/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadmapster
-  VERSION = "1.0.0"
+  VERSION = '1.0.0'
 end

--- a/lib/roadmapster/webhooks/github_issue.rb
+++ b/lib/roadmapster/webhooks/github_issue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rest-client'
 
 module Roadmapster
@@ -10,10 +12,8 @@ module Roadmapster
       end
 
       def should_track?
-        if should_check? && contains_tracker?
-          return true
-        end
-        return false
+        return true if should_check? && contains_tracker?
+        false
       end
 
       def should_check?
@@ -25,9 +25,7 @@ module Roadmapster
         !@tracker.nil?
       end
 
-      def tracker
-        @tracker
-      end
+      attr_reader :tracker
 
       def action
         @payload[:action]

--- a/lib/roadmapster/wizeline/auth.rb
+++ b/lib/roadmapster/wizeline/auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadmapster
   module Wizeline
     class Auth
@@ -10,7 +12,7 @@ module Roadmapster
       end
 
       def token
-        @token ||= post('auth/login', { email: @email, password: @password })[:auth][:token]
+        @token ||= post('auth/login', email: @email, password: @password)[:auth][:token]
       end
     end
   end

--- a/lib/roadmapster/wizeline/base_api.rb
+++ b/lib/roadmapster/wizeline/base_api.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'rest-client'
 require 'json'
 
 module Roadmapster
   module Wizeline
     module BaseApi
-
-      BASE_ENDPOINT = "https://<subdomain>.wizelineroadmap.com/api/"
+      BASE_ENDPOINT = 'https://<subdomain>.wizelineroadmap.com/api/'
 
       def get(resource, **options)
         @resource_options = options

--- a/lib/roadmapster/wizeline/organization.rb
+++ b/lib/roadmapster/wizeline/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadmapster
   module Wizeline
     class Organization

--- a/roadmapster.gemspec
+++ b/roadmapster.gemspec
@@ -1,35 +1,37 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+
+# frozen_string_literal: true
+
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "roadmapster/version"
+require 'roadmapster/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "roadmapster"
+  spec.name          = 'roadmapster'
   spec.version       = Roadmapster::VERSION
-  spec.authors       = ["Ismael Serratos"]
-  spec.email         = ["iaserrat@me.com"]
+  spec.authors       = ['Ismael Serratos']
+  spec.email         = ['iaserrat@me.com']
 
-  spec.summary       = "Unofficial and Open Source Wizeline Roadmap Github Integration"
-  spec.homepage      = "https://github.com/iaserrat/roadmapster"
-  spec.license       = "MIT"
+  spec.summary       = 'Unofficial and Open Source Wizeline Roadmap Github Integration'
+  spec.homepage      = 'https://github.com/iaserrat/roadmapster'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "example.com"
+    spec.metadata['allowed_push_host'] = 'example.com'
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end

--- a/spec/roadmapster_spec.rb
+++ b/spec/roadmapster_spec.rb
@@ -1,7 +1,9 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Roadmapster do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Roadmapster::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'vcr'
 require 'roadmapster'

--- a/spec/wizeline_api/organization_spec.rb
+++ b/spec/wizeline_api/organization_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'vcr'
 
 RSpec.describe Roadmapster::Wizeline::Organization do
-
   before :each do
     @api_token = ENV['WIZELINE_API_TOKEN']
     @organizations = Roadmapster::Wizeline::Organization.new(token: @api_token)

--- a/spec/wizeline_api/roadmap_spec.rb
+++ b/spec/wizeline_api/roadmap_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'vcr'
 
 RSpec.describe Roadmapster::Wizeline::Roadmap do
-
   before :each do
     @api_token = ENV['WIZELINE_API_TOKEN']
     @organization = Roadmapster::Wizeline::Organization.new(token: @api_token).find('M_d4XCCpQ32XQosuGZGAiw')


### PR DESCRIPTION
I ran `rubocop --auto-correct` to generate this pull request.

I omitted changes that are covered in #19 and #20.

After the 3 pull requests are merged, our rubocop offenses should be down to these:

```
11  Metrics/LineLength
8   Style/Documentation
1   Metrics/BlockLength
1   Naming/AccessorMethodName
1   Style/RegexpLiteral
```