### PR TITLE
Add Sucker Punch for backgrounding the processing of webhooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'rest-client'
 gem 'sinatra'
 gem 'sinatra-contrib'
+gem 'sucker_punch', '~> 2.0'
 
 group :test, :development do
   gem 'vcr'

--- a/http/github_routes.rb
+++ b/http/github_routes.rb
@@ -23,10 +23,7 @@ module Http
 
     post '/webhooks/issues' do
       payload = JSON.parse(request.body.read, symbolize_names: true)
-      issue = issue_from_payload(payload)
-      if issue.should_track?
-        create_wizeline_issue(issue)
-      end
+      CreateWizelineIssueJob.perform_async(payload)
       json :ok
     end
   end

--- a/http/github_routes.rb
+++ b/http/github_routes.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'sinatra/json'
 require_relative 'helpers'
+require_relative '../jobs/create_wizeline_issue_job'
 
 module Http
   class GithubRoutes < Sinatra::Base

--- a/jobs/create_wizeline_issue_job.rb
+++ b/jobs/create_wizeline_issue_job.rb
@@ -1,0 +1,12 @@
+require_relative '../http/helpers'
+
+class CreateWizelineIssueJob
+  include SuckerPunch::Job
+  include Http::Helpers
+
+  def perform(payload)
+    issue = issue_from_payload(payload)
+    return unless issue.should_track?
+    create_wizeline_issue(issue)
+  end
+end

--- a/jobs/create_wizeline_issue_job.rb
+++ b/jobs/create_wizeline_issue_job.rb
@@ -1,4 +1,5 @@
 require_relative '../http/helpers'
+require 'sucker_punch'
 
 class CreateWizelineIssueJob
   include SuckerPunch::Job

--- a/spec/jobs/create_wizeline_issue_job_spec.rb
+++ b/spec/jobs/create_wizeline_issue_job_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require_relative '../../jobs/create_wizeline_issue_job'
+
+RSpec.describe CreateWizelineIssueJob do
+  describe '#perform' do
+    before do
+      expect(worker).to receive(:issue_from_payload).with(payload).and_return(issue)
+    end
+
+    let(:payload) do
+      { foo: 'bar' }
+    end
+
+    let(:worker){ CreateWizelineIssueJob.allocate }
+
+    context 'when the issue should be tracked' do
+      let(:issue){ instance_double(Roadmapster::Webhooks::GithubIssue, should_track?: true) }
+
+      it 'creates and returns the issue' do
+        expect(worker).to receive(:create_wizeline_issue).with(issue)
+        worker.perform(payload)
+      end
+    end
+
+    context 'when the issue should not be tracked' do
+      let(:issue){ instance_double(Roadmapster::Webhooks::GithubIssue, should_track?: false) }
+
+      it 'returns nil without creating an issue' do
+        expect(worker).not_to receive(:create_wizeline_issue)
+        worker.perform(payload)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'vcr'
 require 'roadmapster'
 require 'pry'
+require 'sucker_punch/testing/inline'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Closes: #13 

### Reasoning
I used SuckerPunch here because it did not introduce new dependencies such as Redis in order to achieve background processing. Instead SuckerPunch is built on concurrent-ruby and handles the queues and processing via ruby Threads.

### Short-Coming
I couldn't find any tests for the http route processing to make sure this is FULLY tested. If there is a foundation added for those I could definitely add some :)